### PR TITLE
update(msotype): add ms vendor patches

### DIFF
--- a/packages/msotype/index.d.ts
+++ b/packages/msotype/index.d.ts
@@ -367,6 +367,14 @@ export interface AlternativeProperties<TLength = GlobalsString | 0> {
 
 export interface StandardProperties<TLength = GlobalsString | 0> {
   /**
+   * Sets or retrieves the interpolation (resampling) method used to stretch an `<img /> element
+   *
+   * | Inherited | &vert; | Initial |
+   * | --------- | -- | ------------- |
+   * `false` | &vert; |`n/a` |
+   */
+  msInterpolationMode?: MsInterpolationModeProperty;
+  /**
    * | Inherited | &vert; | Initial |
    * | --------- | -- | ------------- |
    * `false` | &vert; |`n/a` |
@@ -3351,6 +3359,14 @@ export interface AlternativePropertiesHyphen<TLength = GlobalsString | 0> {
 
 export interface StandardPropertiesHyphen<TLength = GlobalsString | 0> {
   /**
+   * Sets or retrieves the interpolation (resampling) method used to stretch an `<img /> element
+   *
+   * | Inherited | &vert; | Initial |
+   * | --------- | -- | ------------- |
+   * `false` | &vert; |`n/a` |
+   */
+  'ms-interpolation-mode'?: MsInterpolationModeProperty;
+  /**
    * | Inherited | &vert; | Initial |
    * | --------- | -- | ------------- |
    * `false` | &vert; |`n/a` |
@@ -5969,6 +5985,8 @@ export interface FontPropertiesHyphen<TLength = GlobalsString | 0>
 type GlobalsString = string & {};
 
 type GlobalsNumber = number & {};
+
+export type MsInterpolationModeProperty = 'bicubic' | 'nearest-neighbor';
 
 export type MsoAnsiFontSizeProperty<TLength = GlobalsString | 0> = FontSize | TLength | GlobalsString;
 

--- a/packages/scripts/src/mso/patches/ms.ts
+++ b/packages/scripts/src/mso/patches/ms.ts
@@ -1,0 +1,13 @@
+import { MSOProperties } from '@email-types/data/mso';
+
+export const msPatches: MSOProperties = {
+  'ms-interpolation-mode': {
+    syntax: 'nearest-neighbor | bicubic',
+    description:
+      'Sets or retrieves the interpolation (resampling) method used to stretch an `<img /> element',
+    initial: null,
+    inherited: false,
+    shorthand: false,
+    features: [],
+  },
+};

--- a/packages/scripts/src/mso/properties.ts
+++ b/packages/scripts/src/mso/properties.ts
@@ -1,9 +1,10 @@
 /* eslint-disable import/no-mutable-exports */
 import { properties as rawProperties } from '@email-types/data/mso';
-import { toPascalCase } from '../utils';
-import { parse, AnyDataType } from './parser';
 import { createComment } from './comment';
 import { Category, DataType } from './constants';
+import { parse, AnyDataType } from './parser';
+import { msPatches } from './patches/ms';
+import { toPascalCase } from '../utils';
 
 export interface Property {
   key: string;
@@ -16,10 +17,13 @@ export interface Property {
 }
 
 export let getProperties = (): Property[] => {
-  const entries = Object.entries(rawProperties).sort();
+  const entries = Object.entries({
+    ...rawProperties,
+    ...msPatches,
+  }).sort();
+
   const properties = entries.map(([key, value]) => {
     const types = parse(value.syntax);
-
     const property: Property = {
       key,
       types,


### PR DESCRIPTION
Adds the 1 missing `-ms-` type missing from `csstype`. Since outlook emails are pretty much locked, may consider moving the `-ms-` types into this project.